### PR TITLE
make cli additions generic to work with plugin system

### DIFF
--- a/electrumsv-sdk/contrib/local_azure_tests.py
+++ b/electrumsv-sdk/contrib/local_azure_tests.py
@@ -6,6 +6,7 @@ from pathlib import Path
 MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 commands = [
+    "electrumsv-sdk --version",
     "electrumsv-sdk reset",
 
     "electrumsv-sdk start --background node",
@@ -30,4 +31,3 @@ try:
         subprocess.run(command, shell=True, check=True)
 finally:
     subprocess.run("electrumsv-sdk stop", shell=True, check=True)
-

--- a/electrumsv-sdk/electrumsv_sdk/__main__.py
+++ b/electrumsv-sdk/electrumsv_sdk/__main__.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 
+from electrumsv_sdk.argparsing import NameSpace
 from electrumsv_sdk.components import ComponentOptions
 from electrumsv_sdk.app_state import AppState  # pylint: disable=E0401
 
@@ -31,9 +32,7 @@ def main():
     app_state.arparser.manual_argparsing(sys.argv)
     app_state.handlers.handle_cli_args()
 
-    app_state.selected_component = app_state.selected_start_component or \
-                                   app_state.selected_stop_component or \
-                                   app_state.selected_reset_component
+    app_state.selected_component = app_state.get_selected_component()
 
     component_id = app_state.global_cli_flags[ComponentOptions.ID]
     if app_state.selected_component:
@@ -42,21 +41,21 @@ def main():
         app_state.component_module = app_state.import_plugin_component_from_id(component_id)
 
     # Call relevant entrypoint
-    if app_state.NAMESPACE == app_state.START:
+    if app_state.NAMESPACE == NameSpace.START:
         app_state.controller.start()  # -> install() -> start() -> status_check() plugin entrypoints
 
-    if app_state.NAMESPACE == app_state.STOP:
+    if app_state.NAMESPACE == NameSpace.STOP:
         app_state.controller.stop()  # -> stop() entrypoint of plugin
 
-    if app_state.NAMESPACE == app_state.RESET:
+    if app_state.NAMESPACE == NameSpace.RESET:
         app_state.controller.reset()  # -> reset() entrypoint of plugin
 
     # Special built-in execution pathway (not part of plugin system)
-    if app_state.NAMESPACE == app_state.NODE:
+    if app_state.NAMESPACE == NameSpace.NODE:
         app_state.controller.node()
 
     # Http 'GET' request to status_monitor
-    if app_state.NAMESPACE == app_state.STATUS:
+    if app_state.NAMESPACE == NameSpace.STATUS:
         app_state.controller.status()
 
 

--- a/electrumsv-sdk/electrumsv_sdk/argparsing.py
+++ b/electrumsv-sdk/electrumsv_sdk/argparsing.py
@@ -17,6 +17,15 @@ from .components import ComponentName, ComponentStore
 logger = logging.getLogger("argparsing")
 
 
+class NameSpace:
+    TOP_LEVEL = "top_level"
+    START = "start"
+    STOP = "stop"
+    RESET = "reset"
+    NODE = "node"
+    STATUS = 'status'
+
+
 class ArgParser:
     def __init__(self, app_state: "AppState"):
         self.app_state = app_state
@@ -24,34 +33,18 @@ class ArgParser:
         self.component_store = ComponentStore(self.app_state)
 
     def parse_first_arg(self, arg, cur_cmd_name, subcommand_indices):
-        if arg == "start":
-            cur_cmd_name = self.app_state.START
-            self.app_state.NAMESPACE = self.app_state.START
-            subcommand_indices[self.app_state.START] = []
-        elif arg == self.app_state.STOP:
-            cur_cmd_name = self.app_state.STOP
-            self.app_state.NAMESPACE = self.app_state.STOP
-            subcommand_indices[self.app_state.STOP] = []
-        elif arg == self.app_state.RESET:
-            cur_cmd_name = self.app_state.RESET
-            self.app_state.NAMESPACE = self.app_state.RESET
-            subcommand_indices[self.app_state.RESET] = []
-        elif arg == self.app_state.NODE:
-            cur_cmd_name = self.app_state.NODE
-            self.app_state.NAMESPACE = self.app_state.NODE
-            subcommand_indices[self.app_state.NODE] = []
-        elif arg == self.app_state.STATUS:
-            cur_cmd_name = self.app_state.STATUS
-            self.app_state.NAMESPACE = self.app_state.STATUS
-            subcommand_indices[self.app_state.STATUS] = []
+        if arg in {NameSpace.START, NameSpace.STOP, NameSpace.RESET, NameSpace.NODE}:
+            cur_cmd_name = arg
+            self.app_state.NAMESPACE = arg
+            subcommand_indices[arg] = []
         elif arg == "--help":
-            subcommand_indices[self.app_state.TOP_LEVEL].append(0)
+            subcommand_indices[NameSpace.TOP_LEVEL].append(0)
         elif arg == "--version":
-            subcommand_indices[self.app_state.TOP_LEVEL].append(0)
+            subcommand_indices[NameSpace.TOP_LEVEL].append(0)
         else:
             logger.error("First argument must be one of: "
                 "[start, stop, reset, node, status, --help, --version]")
-            sys.exit()
+            sys.exit(1)
         return cur_cmd_name, subcommand_indices
 
     def manual_argparsing(self, args):
@@ -63,9 +56,9 @@ class ArgParser:
 
         subcommand_indices = {}  # cmd_name: [index_arg1, index_arg2]
 
-        cur_cmd_name = self.app_state.TOP_LEVEL
-        self.app_state.NAMESPACE = self.app_state.TOP_LEVEL
-        subcommand_indices[self.app_state.TOP_LEVEL] = []
+        cur_cmd_name = NameSpace.TOP_LEVEL
+        self.app_state.NAMESPACE = NameSpace.TOP_LEVEL
+        subcommand_indices[NameSpace.TOP_LEVEL] = []
         for index, arg in enumerate(args):
             if index == 0:
                 cur_cmd_name, subcommand_indices = self.parse_first_arg(
@@ -73,10 +66,10 @@ class ArgParser:
                 )
                 continue
 
-            elif self.app_state.NAMESPACE == self.app_state.TOP_LEVEL:
-                subcommand_indices[self.app_state.TOP_LEVEL].append(index)
+            elif self.app_state.NAMESPACE == NameSpace.TOP_LEVEL:
+                subcommand_indices[NameSpace].append(index)
 
-            elif self.app_state.NAMESPACE == self.app_state.START:
+            elif self.app_state.NAMESPACE == NameSpace.START:
                 # <start options>
                 if arg.startswith("--") and not component_selected:
                     subcommand_indices[cur_cmd_name].append(index)
@@ -99,7 +92,7 @@ class ArgParser:
                     self.app_state.component_args.append(arg)
                     continue
 
-            elif self.app_state.NAMESPACE == self.app_state.STOP:
+            elif self.app_state.NAMESPACE == NameSpace.STOP:
                 # <stop options>
                 if arg.startswith("--") and not component_selected:
                     subcommand_indices[cur_cmd_name].append(index)
@@ -118,7 +111,7 @@ class ArgParser:
                     component_selected = True
                     continue
 
-            elif self.app_state.NAMESPACE == self.app_state.RESET:
+            elif self.app_state.NAMESPACE == NameSpace.RESET:
                 # <reset options>
                 if arg.startswith("--") and not component_selected:
                     subcommand_indices[cur_cmd_name].append(index)
@@ -136,170 +129,83 @@ class ArgParser:
                     component_selected = True
                     continue
 
-            elif self.app_state.NAMESPACE == self.app_state.NODE:
+            elif self.app_state.NAMESPACE == NameSpace.NODE:
                 subcommand_indices[cur_cmd_name].append(index)
 
-            elif self.app_state.NAMESPACE == self.app_state.STATUS:
+            elif self.app_state.NAMESPACE == NameSpace.STATUS:
                 pass
 
             # print(f"subcommand_indices={subcommand_indices}, index={index}, arg={arg}")
         self.feed_to_argparsers(args, subcommand_indices)
 
     def update_subcommands_args_map(self, args, subcommand_indices):
-        for cmd_name in subcommand_indices:
-            for index in subcommand_indices[cmd_name]:
-                self.app_state.subcmd_raw_args_map[cmd_name].append(args[index])
+        for namespace in subcommand_indices:
+            for index in subcommand_indices[namespace]:
+                self.app_state.parser_raw_args_map[namespace].append(args[index])
 
     def feed_to_argparsers(self, args, subcommand_indices):
         """feeds relevant arguments to each child (or parent) ArgumentParser"""
         self.update_subcommands_args_map(args, subcommand_indices)
 
-        for cmd_name in self.app_state.subcmd_map:
-            if cmd_name == self.app_state.NODE:
-                parsed_args = self.app_state.subcmd_raw_args_map[cmd_name]
+        for cmd_name in self.app_state.parser_map:
+            if cmd_name == NameSpace.NODE:
+                parsed_args = self.app_state.parser_raw_args_map[cmd_name]
             else:
-                parsed_args = self.app_state.subcmd_map[cmd_name].parse_args(
-                    args=self.app_state.subcmd_raw_args_map[cmd_name]
+                parsed_args = self.app_state.parser_map[cmd_name].parse_args(
+                    args=self.app_state.parser_raw_args_map[cmd_name]
                 )
-            self.app_state.subcmd_parsed_args_map[cmd_name] = parsed_args
-
-    def add_subparser_electrumsv(self, subparsers):
-        electrumsv = subparsers.add_parser(ComponentName.ELECTRUMSV, help="start electrumsv")
-        return subparsers, electrumsv
-
-    def add_subparser_electrumsv_node(self, subparsers):
-        node = subparsers.add_parser(ComponentName.NODE, help="start node")
-        return subparsers, node
-
-    def add_subparser_electrumx(self, subparsers):
-        electrumx = subparsers.add_parser(ComponentName.ELECTRUMX, help="start electrumx")
-        return subparsers, electrumx
-
-    def add_subparser_indexer(self, subparsers):
-        electrumsv = subparsers.add_parser(ComponentName.INDEXER, help="start indexer")
-        return subparsers, electrumsv
-
-    def add_subparser_status_monitor(self, subparsers):
-        status_monitor = subparsers.add_parser(ComponentName.STATUS_MONITOR,
-            help="start status monitor")
-        return subparsers, status_monitor
-
-    def add_subparser_woc(self, subparsers):
-        woc = subparsers.add_parser(ComponentName.WHATSONCHAIN, help="start whatsonchain explorer")
-        return subparsers, woc
-
-    def add_start_parser_args(self, start_parser):
-        start_parser.add_argument("--new", action="store_true", help="")
-        start_parser.add_argument("--gui", action="store_true", help="")
-        start_parser.add_argument("--background", action="store_true", help="")
-        start_parser.add_argument(
-            "--id",
-            type=str,
-            default="",
-            help="human-readable identifier for component (e.g. 'worker1_esv')",
-        )
-        start_parser.add_argument(
-            "--repo",
-            type=str,
-            default="",
-            help="git repo as either an https://github.com url or a local git repo path "
-                 "e.g. G:/electrumsv (optional)",
-        )
-        start_parser.add_argument(
-            "--branch",
-            type=str,
-            default="",
-            help="git repo branch (optional)"
-        )
-        return start_parser
+            self.app_state.parser_parsed_args_map[cmd_name] = parsed_args
 
     def add_start_argparser(self, namespaces):
         start_parser = namespaces.add_parser("start", help="specify which servers to run")
-        start_parser = self.add_start_parser_args(start_parser)
+        start_parser.add_argument("--new", action="store_true", help="")
+        start_parser.add_argument("--gui", action="store_true", help="")
+        start_parser.add_argument("--background", action="store_true", help="")
+        start_parser.add_argument("--id", type=str, default="", help="human-readable identifier "
+            "for component (e.g. 'worker1_esv')")
+        start_parser.add_argument("--repo", type=str, default="", help="git repo as either an "
+            "https://github.com url or a local git repo path e.g. G:/electrumsv (optional)")
+        start_parser.add_argument("--branch", type=str, default="", help="git repo branch ("
+            "optional)")
 
+        # add <component_types> from plugins
         subparsers = start_parser.add_subparsers(help="subcommand", required=False)
-        subparsers, electrumsv = self.add_subparser_electrumsv(subparsers)
-        subparsers, electrumx = self.add_subparser_electrumx(subparsers)
-        subparsers, status = self.add_subparser_status_monitor(subparsers)
-        subparsers, electrumsv_node = self.add_subparser_electrumsv_node(subparsers)
-        subparsers, electrumsv_indexer = self.add_subparser_indexer(subparsers)
-        subparsers, woc = self.add_subparser_woc(subparsers)
-
-        start_namespace_subcommands = [
-            electrumsv,
-            electrumx,
-            status,
-            electrumsv_node,
-            electrumsv_indexer,
-            woc,
-        ]
+        start_namespace_subcommands = []
+        for component_type in self.app_state.component_store.component_list:
+            component_parser = subparsers.add_parser(component_type, help=f"start {component_type}")
+            start_namespace_subcommands.append(component_parser)
         return start_parser, start_namespace_subcommands
 
     def add_stop_argparser(self, namespaces):
         stop_parser = namespaces.add_parser("stop", help="stop all spawned processes")
-        stop_parser.add_argument(
-            "--id",
-            type=str,
-            default="",
-            help="human-readable identifier for component (e.g. 'electrumsv1')",
-        )
+        stop_parser.add_argument("--id", type=str, default="", help="human-readable identifier "
+            "for component (e.g. 'electrumsv1')")
 
-        # Stop based on ComponentName
+        # add <component_types> from plugins
         subparsers = stop_parser.add_subparsers(help="subcommand", required=False)
-        electrumsv_node = subparsers.add_parser(ComponentName.NODE, help="stop node")
-        electrumx = subparsers.add_parser(ComponentName.ELECTRUMX, help="stop electrumx")
-        electrumsv = subparsers.add_parser(ComponentName.ELECTRUMSV, help="stop electrumsv")
-        electrumsv_indexer = subparsers.add_parser(ComponentName.INDEXER, help="stop indexer")
-        status = subparsers.add_parser(ComponentName.STATUS_MONITOR, help="stop status monitor")
+        stop_namespace_subcommands = []
+        for component_type in self.app_state.component_store.component_list:
+            component_parser = subparsers.add_parser(component_type, help=f"stop {component_type}")
+            stop_namespace_subcommands.append(component_parser)
 
-        stop_namespace_subcommands = [
-            electrumsv,
-            electrumsv_node,
-            electrumx,
-            electrumsv_indexer,
-            status,
-        ]
         return stop_parser, stop_namespace_subcommands
 
     def add_reset_argparser(self, namespaces):
-        reset_parser = namespaces.add_parser(
-            "reset", help="reset state of relevant servers to genesis"
-        )
-        reset_parser.add_argument(
-            "--id",
-            type=str,
-            default="",
-            help="human-readable identifier for component (e.g. 'electrumsv1')",
-        )
-        reset_parser.add_argument(
-            "--repo",
-            type=str,
-            default="",
-            help="git repo as either an https://github.com url or a local git repo path "
-                 "e.g. G:/electrumsv (optional)",
-        )
-        reset_parser.add_argument(
-            "--branch",
-            type=str,
-            default="",
-            help="git repo branch (optional)"
-        )
+        """only relevant for component types with a datadir (e.g. node, electrumx, electrumsv)"""
+        reset_parser = namespaces.add_parser("reset", help="reset state of relevant servers to "
+            "genesis")
+        reset_parser.add_argument("--id", type=str, default="", help="human-readable identifier "
+            "for component (e.g. 'electrumsv1')")
+        reset_parser.add_argument("--repo", type=str, default="", help="git repo as either an "
+            "https://github.com url or a local git repo path e.g. G:/electrumsv (optional)")
 
-        # Stop based on ComponentName
+        # add <component_types> from plugins
         subparsers = reset_parser.add_subparsers(help="subcommand", required=False)
-        electrumsv_node = subparsers.add_parser(ComponentName.NODE, help="reset node")
-        electrumx = subparsers.add_parser(ComponentName.ELECTRUMX, help="reset electrumx")
-        electrumsv = subparsers.add_parser(ComponentName.ELECTRUMSV, help="reset electrumsv")
-        electrumsv_indexer = subparsers.add_parser(ComponentName.INDEXER, help="reset indexer")
-        status = subparsers.add_parser(ComponentName.STATUS_MONITOR, help="reset status monitor")
+        reset_namespace_subcommands = []
+        for component_type in self.app_state.component_store.component_list:
+            component_parser = subparsers.add_parser(component_type, help=f"reset {component_type}")
+            reset_namespace_subcommands.append(component_parser)
 
-        reset_namespace_subcommands = [
-            electrumsv,
-            electrumsv_node,
-            electrumx,
-            electrumsv_indexer,
-            status,
-        ]
         return reset_parser, reset_namespace_subcommands
 
     def add_node_argparser(self, namespaces):
@@ -337,28 +243,16 @@ class ArgParser:
         status_parser = self.add_status_argparser(namespaces)
 
         # register top-level ArgumentParsers
-        self.app_state.subcmd_map[self.app_state.TOP_LEVEL] = top_level_parser
-        self.app_state.subcmd_map[self.app_state.START] = start_parser
-        self.app_state.subcmd_map[self.app_state.STOP] = stop_parser
-        self.app_state.subcmd_map[self.app_state.RESET] = reset_parser
-        self.app_state.subcmd_map[self.app_state.NODE] = node_parser
-        self.app_state.subcmd_map[self.app_state.STATUS] = status_parser
+        self.app_state.parser_map[NameSpace.TOP_LEVEL] = top_level_parser
+        self.app_state.parser_map[NameSpace.START] = start_parser
+        self.app_state.parser_map[NameSpace.STOP] = stop_parser
+        self.app_state.parser_map[NameSpace.RESET] = reset_parser
+        self.app_state.parser_map[NameSpace.NODE] = node_parser
+        self.app_state.parser_map[NameSpace.STATUS] = status_parser
 
-        # register subcommands second so that handlers are called in desired ordering
-        for cmd in start_namespace_subcommands:
-            cmd_name = cmd.prog.split(sep=" ")[2]
-            self.app_state.subcmd_map[cmd_name] = cmd
-
-        for cmd in stop_namespace_subcommands:
-            cmd_name = cmd.prog.split(sep=" ")[2]
-            self.app_state.subcmd_map[cmd_name] = cmd
-
-        for cmd in reset_namespace_subcommands:
-            cmd_name = cmd.prog.split(sep=" ")[2]
-            self.app_state.subcmd_map[cmd_name] = cmd
-
-        for cmd_name in self.app_state.subcmd_map.keys():
-            self.app_state.subcmd_raw_args_map[cmd_name] = []
+        # prepare raw_args
+        for namespace in self.app_state.parser_map.keys():
+            self.app_state.parser_raw_args_map[namespace] = []
 
     def set_help_text(self):
         self.help_text = textwrap.dedent(

--- a/electrumsv-sdk/electrumsv_sdk/builtin_components/electrumsv/electrumsv.py
+++ b/electrumsv-sdk/electrumsv_sdk/builtin_components/electrumsv/electrumsv.py
@@ -90,8 +90,8 @@ def reset(app_state):
 
 def status_check(app_state) -> Optional[bool]:
     """
-    True -> ComponentState.Running;
-    False -> ComponentState.Failed;
+    True -> ComponentState.RUNNING;
+    False -> ComponentState.FAILED;
     None -> skip status monitoring updates (e.g. using app's cli interface transiently)
     """
     # Offline CLI interface

--- a/electrumsv-sdk/electrumsv_sdk/builtin_components/electrumsv/install.py
+++ b/electrumsv-sdk/electrumsv_sdk/builtin_components/electrumsv/install.py
@@ -78,14 +78,14 @@ def packages_electrumsv(app_state, url, branch):
     checkout_branch(branch)
 
     if sys.platform == 'win32':
-        cmd1 = f"{app_state.python} -m pip install --user -r " \
+        cmd1 = f"{app_state.python} -m pip install --user --upgrade -r " \
                f"{app_state.electrumsv_requirements_path}"
-        cmd2 = f"{app_state.python} -m pip install --user -r " \
+        cmd2 = f"{app_state.python} -m pip install --user --upgrade -r " \
                f"{app_state.electrumsv_binary_requirements_path}"
     elif sys.platform in ['linux', 'darwin']:
-        cmd1 = f"sudo {app_state.python} -m pip install -r " \
+        cmd1 = f"sudo {app_state.python} -m pip install --upgrade -r " \
                f"{app_state.electrumsv_requirements_path}"
-        cmd2 = f"sudo {app_state.python} -m pip install -r " \
+        cmd2 = f"sudo {app_state.python} -m pip install --upgrade -r " \
                f"{app_state.electrumsv_binary_requirements_path}"
 
     process1 = subprocess.Popen(cmd1, shell=True)
@@ -140,12 +140,8 @@ def make_esv_gui_script(base_cmd, env_vars, esv_data_dir, port):
 def generate_run_scripts_electrumsv(app_state):
     """makes both the daemon script and a script for running the GUI"""
     app_state.init_run_script_dir()
-    path_to_dapp_example_apps = app_state.component_source_dir.joinpath("examples").joinpath(
-        "applications"
-    )
-    esv_env_vars = {
-        "PYTHONPATH": str(path_to_dapp_example_apps),
-    }
+    path_to_dapp_example_apps = app_state.component_source_dir.joinpath("examples/applications")
+    esv_env_vars = {"PYTHONPATH": str(path_to_dapp_example_apps)}
     esv_script = str(app_state.component_source_dir.joinpath("electrum-sv"))
     esv_data_dir = app_state.component_datadir
     port = app_state.component_port

--- a/electrumsv-sdk/electrumsv_sdk/builtin_components/electrumx/electrumx.py
+++ b/electrumsv-sdk/electrumsv_sdk/builtin_components/electrumx/electrumx.py
@@ -4,7 +4,7 @@ import os
 import shutil
 from typing import Optional
 
-from electrumsv_sdk.components import ComponentOptions, ComponentName, Component
+from electrumsv_sdk.components import ComponentOptions, Component
 from electrumsv_sdk.utils import is_remote_repo, get_directory_name
 
 from .install import configure_paths, fetch_electrumx, packages_electrumx, \
@@ -36,12 +36,11 @@ def install(app_state):
 
 
 def start(app_state):
-    component_name = ComponentName.ELECTRUMX
     logger.debug(f"Starting RegTest electrumx server...")
-    script_path = app_state.derive_shell_script_path(ComponentName.ELECTRUMX)
+    script_path = app_state.derive_shell_script_path(COMPONENT_NAME)
     process = app_state.spawn_process(script_path)
-    id = app_state.get_id(component_name)
-    app_state.component_info = Component(id, process.pid, ComponentName.ELECTRUMX,
+    id = app_state.get_id(COMPONENT_NAME)
+    app_state.component_info = Component(id, process.pid, COMPONENT_NAME,
         location=str(app_state.component_source_dir), status_endpoint="http://127.0.0.1:51001",
         metadata={"data_dir": str(app_state.component_data_dir)}, logging_path=None)
 
@@ -51,6 +50,7 @@ def stop(app_state):
     generic 'app_state.kill_component()' function to track down the pid and kill the process."""
     app_state.kill_component()
     logger.info(f"stopped selected {COMPONENT_NAME} instance(s) (if any)")
+
 
 def reset(app_state):
     repo = app_state.global_cli_flags[ComponentOptions.REPO]
@@ -69,8 +69,8 @@ def reset(app_state):
 
 def status_check(app_state) -> Optional[bool]:
     """
-    True -> ComponentState.Running;
-    False -> ComponentState.Failed;
+    True -> ComponentState.RUNNING;
+    False -> ComponentState.FAILED;
     None -> skip status monitoring updates (e.g. using app's cli interface transiently)
     """
     is_running = asyncio.run(is_electrumx_running())

--- a/electrumsv-sdk/electrumsv_sdk/builtin_components/node/node.py
+++ b/electrumsv-sdk/electrumsv_sdk/builtin_components/node/node.py
@@ -4,7 +4,7 @@ from typing import Optional, Dict
 
 from electrumsv_node import electrumsv_node
 
-from electrumsv_sdk.components import ComponentOptions, ComponentName, Component
+from electrumsv_sdk.components import ComponentOptions, Component
 from electrumsv_sdk.utils import get_directory_name
 
 from .install import fetch_node, configure_paths
@@ -28,16 +28,15 @@ def install(app_state):
 
 
 def start(app_state):
-    component_name = ComponentName.NODE
     rpcport = app_state.component_port
     p2p_port = app_state.component_p2p_port
     data_path = app_state.component_datadir
-    id = app_state.get_id(component_name)
+    id = app_state.get_id(COMPONENT_NAME)
     process_pid = electrumsv_node.start(data_path=data_path, rpcport=rpcport,
                                         p2p_port=p2p_port, network='regtest')
     logging_path = Path(app_state.component_datadir).joinpath("regtest/bitcoind.log")
 
-    app_state.component_info = Component(id, process_pid, component_name,
+    app_state.component_info = Component(id, process_pid, COMPONENT_NAME,
         str(app_state.component_source_dir),
         f"http://rpcuser:rpcpassword@127.0.0.1:{rpcport}",
         logging_path=logging_path,
@@ -82,8 +81,8 @@ def reset(app_state):
 
 def status_check(app_state) -> Optional[bool]:
     """
-    True -> ComponentState.Running;
-    False -> ComponentState.Failed;
+    True -> ComponentState.RUNNING;
+    False -> ComponentState.FAILED;
     None -> skip status monitoring updates (e.g. using app's cli interface transiently)
     """
     return app_state.node_status_check_result

--- a/electrumsv-sdk/electrumsv_sdk/builtin_components/status_monitor/status_monitor.py
+++ b/electrumsv-sdk/electrumsv_sdk/builtin_components/status_monitor/status_monitor.py
@@ -3,7 +3,7 @@ import os
 import sys
 from typing import Optional
 
-from electrumsv_sdk.components import ComponentOptions, ComponentName, Component
+from electrumsv_sdk.components import ComponentOptions, Component
 from electrumsv_sdk.constants import ComponentLaunchFailedError
 from electrumsv_sdk.utils import get_directory_name
 
@@ -29,10 +29,9 @@ def install(app_state):
 
 
 def start(app_state):
-    component_name = ComponentName.STATUS_MONITOR
     logger.debug(f"Starting status monitor daemon...")
     try:
-        script_path = app_state.derive_shell_script_path(component_name)  # move to app_state
+        script_path = app_state.derive_shell_script_path(COMPONENT_NAME)  # move to app_state
         process = app_state.spawn_process(script_path)
     except ComponentLaunchFailedError:
         log_path = app_state.status_monitor_logging_path
@@ -42,8 +41,8 @@ def start(app_state):
             logger.debug(f"see {log_path.joinpath(log_files[0])} for details")
         sys.exit(1)
 
-    id = app_state.get_id(component_name)
-    app_state.component_info = Component(id, process.pid, component_name,
+    id = app_state.get_id(COMPONENT_NAME)
+    app_state.component_info = Component(id, process.pid, COMPONENT_NAME,
         str(app_state.status_monitor_dir), "http://127.0.0.1:5000/api/status/get_status")
 
 
@@ -53,14 +52,15 @@ def stop(app_state):
     app_state.kill_component()
     logger.info(f"stopped selected {COMPONENT_NAME} instance(s) (if any)")
 
+
 def reset(app_state):
     logger.info("resetting the status monitor is not supported.")
 
 
 def status_check(app_state) -> Optional[bool]:
     """
-    True -> ComponentState.Running;
-    False -> ComponentState.Failed;
+    True -> ComponentState.RUNNING;
+    False -> ComponentState.FAILED;
     None -> skip status monitoring updates (e.g. using app's cli interface transiently)
     """
     is_running = app_state.is_component_running_http(

--- a/electrumsv-sdk/electrumsv_sdk/builtin_components/whatsonchain/whatsonchain.py
+++ b/electrumsv-sdk/electrumsv_sdk/builtin_components/whatsonchain/whatsonchain.py
@@ -2,7 +2,7 @@ import logging
 import sys
 from typing import Optional
 
-from electrumsv_sdk.components import ComponentOptions, ComponentName, Component
+from electrumsv_sdk.components import ComponentOptions, Component
 from electrumsv_sdk.utils import get_directory_name
 
 from .install import fetch_whatsonchain, generate_run_script_whatsonchain, packages_whatsonchain
@@ -32,15 +32,14 @@ def install(app_state):
 
 
 def start(app_state):
-    component_name = ComponentName.WHATSONCHAIN
     logger.debug(f"Starting whatsonchain daemon...")
     if not check_node_for_woc():
         sys.exit(1)
 
-    script_path = app_state.derive_shell_script_path(component_name)
+    script_path = app_state.derive_shell_script_path(COMPONENT_NAME)
     process = app_state.spawn_process(script_path)
-    id = app_state.get_id(component_name)
-    app_state.component_info = Component(id, process.pid, component_name,
+    id = app_state.get_id(COMPONENT_NAME)
+    app_state.component_info = Component(id, process.pid, COMPONENT_NAME,
         str(app_state.woc_dir), "http://127.0.0.1:3002")
 
 
@@ -50,14 +49,15 @@ def stop(app_state):
     app_state.kill_component()
     logger.info(f"stopped selected {COMPONENT_NAME} instance(s) (if any)")
 
+
 def reset(app_state):
     logger.info("resetting the whatsonchain is not applicable")
 
 
 def status_check(app_state) -> Optional[bool]:
     """
-    True -> ComponentState.Running;
-    False -> ComponentState.Failed;
+    True -> ComponentState.RUNNING;
+    False -> ComponentState.FAILED;
     None -> skip status monitoring updates (e.g. using app's cli interface transiently)
     """
     is_running = app_state.is_component_running_http(

--- a/electrumsv-sdk/electrumsv_sdk/controller.py
+++ b/electrumsv-sdk/electrumsv_sdk/controller.py
@@ -83,7 +83,7 @@ class Controller:
         if component_list:
             for component_dict in component_list:
                 component_obj = Component.from_dict(component_dict)
-                component_obj.component_state = str(ComponentState.Stopped)
+                component_obj.component_state = ComponentState.STOPPED
                 self.app_state.component_store.update_status_file(component_obj)
                 if status_monitor_is_selected_stop_component:
                     return  # skip impossible task of updating itself after killing itself...
@@ -154,11 +154,11 @@ class Controller:
                 return
 
             if is_running is False:
-                self.app_state.component_info.component_state = ComponentState.Failed
+                self.app_state.component_info.component_state = ComponentState.FAILED
                 logger.error(f"{component_name} failed to start")
 
             elif is_running is True:
-                self.app_state.component_info.component_state = ComponentState.Running
+                self.app_state.component_info.component_state = ComponentState.RUNNING
                 logger.debug(f"{component_name} online")
             self.app_state.component_store.update_status_file(self.app_state.component_info)
             self.app_state.status_monitor_client.update_status(self.app_state.component_info)

--- a/electrumsv-sdk/electrumsv_sdk/utils.py
+++ b/electrumsv-sdk/electrumsv_sdk/utils.py
@@ -11,6 +11,7 @@ from electrumsv_node import electrumsv_node
 logger = logging.getLogger("utils")
 MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
 
+
 def checkout_branch(branch: str):
     if branch != "":
         subprocess.run(f"git checkout {branch}", shell=True, check=True)


### PR DESCRIPTION
- make start, stop and reset generic with respect to <component_type> from the plugin directories
- change ComponentState to be regular class attributes as strings (not enums)
- make argparser handlers generic and use argparsing.NameSpace class (removing this clutter from app_state)
- linting and other minor tidy ups