### PR TITLE
fixes for linux

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,8 +49,8 @@ jobs:
       displayName: 'prepare for whatsonchain'
       workingDirectory: electrumsv-sdk/
     - script: |
-        electrumsv-sdk start --background node
-        electrumsv-sdk start --background electrumx
+        electrumsv-sdk start --background --new node
+        electrumsv-sdk start --background --new electrumx
         electrumsv-sdk start --background --new electrumsv
 
         electrumsv-sdk node generate 1
@@ -92,8 +92,8 @@ jobs:
         py -3 -m pip install wheel
         py -3 -m pip install -e .
         py -3 -m pip install pytest pytest-cov
-        electrumsv-sdk start --background node
-        electrumsv-sdk start --background electrumx
+        electrumsv-sdk start --background --new node
+        electrumsv-sdk start --background --new electrumx
         electrumsv-sdk start --background --new electrumsv
 
         electrumsv-sdk node generate 1

--- a/electrumsv-sdk/contrib/local_azure_tests.py
+++ b/electrumsv-sdk/contrib/local_azure_tests.py
@@ -11,9 +11,9 @@ commands = [
     "electrumsv-sdk reset",
 
     "electrumsv-sdk start --background status_monitor",
-    "electrumsv-sdk start --background node",
-    "electrumsv-sdk start --background electrumx",
-    "electrumsv-sdk start --background electrumsv",
+    "electrumsv-sdk start --background --new node",
+    "electrumsv-sdk start --background --new electrumx",
+    "electrumsv-sdk start --background --new electrumsv",
     "electrumsv-sdk node generate 1",
     "electrumsv-sdk start --background whatsonchain",
 

--- a/electrumsv-sdk/electrumsv_sdk/app_state.py
+++ b/electrumsv-sdk/electrumsv_sdk/app_state.py
@@ -76,14 +76,7 @@ class AppState:
 
         self.component_module: Optional[ModuleType] = None  # e.g. builtin_components.node
         self.component_info: Optional[Component] = None  # dict conversion <-> status_monitor
-
-        if sys.platform in ['linux', 'darwin']:
-            self.linux_venv_dir = self.sdk_home_dir.joinpath("sdk_venv")
-            self.python = str(self.linux_venv_dir.joinpath("bin").joinpath("python"))
-            self.run_command_current_shell(
-                f"{sys.executable} -m venv {self.linux_venv_dir}")
-        else:
-            self.python: str = sys.executable
+        self.python = sys.executable
 
         # namespaces and argparsing
         self.NAMESPACE = ""  # 'start', 'stop', 'reset', 'node', or 'status'
@@ -199,9 +192,9 @@ class AppState:
             .joinpath("requirements.txt")
         sdk_requirements_linux_path = Path(MODULE_DIR).parent.joinpath("requirements").joinpath(
             "requirements-linux.txt")
-        subprocess.run(f"sudo {python} -m pip install -r {sdk_requirements_path}",
+        subprocess.run(f"{python} -m pip install --user -r {sdk_requirements_path}",
                        shell=True, check=True)
-        subprocess.run(f"sudo {python} -m pip install -r {sdk_requirements_linux_path}",
+        subprocess.run(f"{python} -m pip install --user -r {sdk_requirements_linux_path}",
                        shell=True, check=True)
 
     def handle_first_ever_run(self) -> None:

--- a/electrumsv-sdk/electrumsv_sdk/builtin_components/electrumsv/electrumsv.py
+++ b/electrumsv-sdk/electrumsv_sdk/builtin_components/electrumsv/electrumsv.py
@@ -59,12 +59,11 @@ def start(app_state):
     script_path = app_state.derive_shell_script_path(COMPONENT_NAME)
     process = app_state.spawn_process(f"{script_path}")
 
-    id = app_state.get_id(COMPONENT_NAME)
     logging_path = app_state.component_datadir.joinpath("logs")
     metadata = {"config": str(app_state.component_datadir.joinpath("regtest/config")),
                 "datadir": str(app_state.component_datadir)}
 
-    app_state.component_info = Component(id, process.pid, COMPONENT_NAME,
+    app_state.component_info = Component(app_state.component_id, process.pid, COMPONENT_NAME,
         str(app_state.component_source_dir), f"http://127.0.0.1:{app_state.component_port}",
         metadata=metadata, logging_path=logging_path)
 

--- a/electrumsv-sdk/electrumsv_sdk/builtin_components/electrumsv/install.py
+++ b/electrumsv-sdk/electrumsv_sdk/builtin_components/electrumsv/install.py
@@ -23,11 +23,11 @@ def configure_paths(app_state, repo, branch):
             checkout_branch(branch)
         app_state.component_source_dir = Path(repo)
 
-    app_state.component_datadir = app_state.get_component_datadir(COMPONENT_NAME)
-
-    component_id = app_state.get_id(COMPONENT_NAME)
+    if not app_state.component_datadir:
+        app_state.component_datadir, app_state.component_id = \
+            app_state.get_component_datadir(COMPONENT_NAME)
     app_state.component_port = app_state.get_component_port(DEFAULT_PORT,
-        COMPONENT_NAME, component_id)
+        COMPONENT_NAME, app_state.component_id)
 
 
 def fetch_electrumsv(app_state, url, branch):

--- a/electrumsv-sdk/electrumsv_sdk/builtin_components/electrumsv/install.py
+++ b/electrumsv-sdk/electrumsv_sdk/builtin_components/electrumsv/install.py
@@ -87,9 +87,9 @@ def packages_electrumsv(app_state, url, branch):
         cmd2 = f"{app_state.python} -m pip install --user --upgrade -r " \
                f"{electrumsv_binary_requirements_path}"
     elif sys.platform in ['linux', 'darwin']:
-        cmd1 = f"sudo {app_state.python} -m pip install --upgrade -r " \
+        cmd1 = f"{app_state.python} -m pip install --user --upgrade -r " \
                f"{electrumsv_requirements_path}"
-        cmd2 = f"sudo {app_state.python} -m pip install --upgrade -r " \
+        cmd2 = f"{app_state.python} -m pip install --user --upgrade -r " \
                f"{electrumsv_binary_requirements_path}"
 
     process1 = subprocess.Popen(cmd1, shell=True)

--- a/electrumsv-sdk/electrumsv_sdk/builtin_components/electrumx/electrumx.py
+++ b/electrumsv-sdk/electrumsv_sdk/builtin_components/electrumx/electrumx.py
@@ -43,8 +43,7 @@ def start(app_state):
     logger.debug(f"Starting RegTest electrumx server...")
     script_path = app_state.derive_shell_script_path(COMPONENT_NAME)
     process = app_state.spawn_process(f"{script_path}")
-    id = app_state.get_id(COMPONENT_NAME)
-    app_state.component_info = Component(id, process.pid, COMPONENT_NAME,
+    app_state.component_info = Component(app_state.component_id, process.pid, COMPONENT_NAME,
         location=str(app_state.component_source_dir), status_endpoint="http://127.0.0.1:51001",
         metadata={"datadir": str(app_state.component_datadir)}, logging_path=None)
 

--- a/electrumsv-sdk/electrumsv_sdk/builtin_components/electrumx/install.py
+++ b/electrumsv-sdk/electrumsv_sdk/builtin_components/electrumx/install.py
@@ -80,7 +80,7 @@ def packages_electrumx(app_state, url, branch):
 
     if sys.platform in ['linux', 'darwin']:
         process = subprocess.Popen(
-            f"sudo {app_state.python} -m pip install -r {requirements_path}", shell=True)
+            f"{app_state.python} -m pip install --user -r {requirements_path}", shell=True)
         process.wait()
 
     elif sys.platform == 'win32':

--- a/electrumsv-sdk/electrumsv_sdk/builtin_components/electrumx/install.py
+++ b/electrumsv-sdk/electrumsv_sdk/builtin_components/electrumx/install.py
@@ -21,10 +21,11 @@ def configure_paths(app_state, repo, branch):
             checkout_branch(branch)
         app_state.component_source_dir = Path(repo)
 
-    app_state.component_datadir = app_state.get_component_datadir(COMPONENT_NAME)
-    component_id = app_state.get_id(COMPONENT_NAME)
+    if not app_state.component_datadir:
+        app_state.component_datadir, app_state.component_id = \
+            app_state.get_component_datadir(COMPONENT_NAME)
     app_state.component_port = app_state.get_component_port(DEFAULT_PORT_ELECTRUMX, COMPONENT_NAME,
-        component_id)
+        app_state.component_id)
 
 
 def fetch_electrumx(app_state, url, branch):

--- a/electrumsv-sdk/electrumsv_sdk/builtin_components/electrumx/install.py
+++ b/electrumsv-sdk/electrumsv_sdk/builtin_components/electrumx/install.py
@@ -115,6 +115,7 @@ def generate_run_script(app_state):
         f"{env_var_setter} MAX_SEND=10000000",
         f"{env_var_setter} LOG_LEVEL=debug",
         f"{env_var_setter} NET=regtest",
+        f"{env_var_setter} ALLOW_ROOT=1",
         f"{app_state.python} {app_state.component_source_dir.joinpath('electrumx_server')}"
     ]
     app_state.make_shell_script_for_component(list_of_shell_commands=lines,

--- a/electrumsv-sdk/electrumsv_sdk/builtin_components/node/install.py
+++ b/electrumsv-sdk/electrumsv_sdk/builtin_components/node/install.py
@@ -14,12 +14,14 @@ logger = logging.getLogger(COMPONENT_NAME)
 
 def configure_paths(app_state, repo=None, branch=None):
     app_state.component_source_dir = Path(electrumsv_node.FILE_PATH).parent
-    app_state.component_datadir = app_state.get_component_datadir(COMPONENT_NAME)
-    component_id = app_state.get_id(COMPONENT_NAME)
+    if not app_state.component_datadir:
+        app_state.component_datadir, app_state.component_id = \
+            app_state.get_component_datadir(COMPONENT_NAME)
+
     app_state.component_port = app_state.get_component_port(DEFAULT_PORT, COMPONENT_NAME,
-                                                            component_id)
+                                                            app_state.component_id)
     app_state.component_p2p_port = app_state.get_component_port(DEFAULT_P2P_PORT_NODE,
-        COMPONENT_NAME, component_id)
+        COMPONENT_NAME, app_state.component_id)
 
 
 def fetch_node(app_state):

--- a/electrumsv-sdk/electrumsv_sdk/builtin_components/node/node.py
+++ b/electrumsv-sdk/electrumsv_sdk/builtin_components/node/node.py
@@ -34,12 +34,12 @@ def start(app_state):
     rpcport = app_state.component_port
     p2p_port = app_state.component_p2p_port
     data_path = app_state.component_datadir
-    id = app_state.get_id(COMPONENT_NAME)
+    component_id = app_state.component_id
     process_pid = electrumsv_node.start(data_path=data_path, rpcport=rpcport,
                                         p2p_port=p2p_port, network='regtest')
     logging_path = Path(app_state.component_datadir).joinpath("regtest/bitcoind.log")
 
-    app_state.component_info = Component(id, process_pid, COMPONENT_NAME,
+    app_state.component_info = Component(component_id, process_pid, COMPONENT_NAME,
         str(app_state.component_source_dir),
         f"http://rpcuser:rpcpassword@127.0.0.1:{rpcport}",
         logging_path=logging_path,

--- a/electrumsv-sdk/electrumsv_sdk/status_server/server.py
+++ b/electrumsv-sdk/electrumsv_sdk/status_server/server.py
@@ -5,7 +5,6 @@ import time
 from functools import partial
 from pathlib import Path
 from typing import Optional, Dict
-
 import curio
 import logging
 import logging.handlers

--- a/electrumsv-sdk/setup.py
+++ b/electrumsv-sdk/setup.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 import os
+import site
 
 from setuptools import find_packages, setup
 import sys
+site.ENABLE_USER_SITE = "--user" in sys.argv[1:]
 
 _ = """
 py -3.7-32 .\setup.py build bdist_wheel --plat-name win32

--- a/electrumsv-sdk/setup.py
+++ b/electrumsv-sdk/setup.py
@@ -4,8 +4,7 @@ import os
 from setuptools import find_packages, setup
 import sys
 
-
-"""
+_ = """
 py -3.7-32 .\setup.py build bdist_wheel --plat-name win32
 py -3.8-32 .\setup.py build bdist_wheel --plat-name win32
 py -3.7 .\setup.py build bdist_wheel --plat-name win-amd64
@@ -20,8 +19,7 @@ py -3.8 -m pip uninstall electrumsv-sdk
 
 and install the one you want:
 py -3.8 -m pip install electrumsv-sdk
-"""  # pylint: disable=W0105
-
+"""
 
 with open('electrumsv_sdk/__init__.py', 'r') as f:
     for line in f:
@@ -31,7 +29,7 @@ with open('electrumsv_sdk/__init__.py', 'r') as f:
 
 
 def _locate_requirements():
-    requirement_files = [ "requirements.txt" ]
+    requirement_files = ["requirements.txt"]
     if sys.platform == 'win32':
         requirement_files.append("requirements-win32.txt")
     elif sys.platform in ('linux', 'darwin'):


### PR DESCRIPTION
reset entrypoint was not called when component had never been started before

- now the reset method should always be called and the handling of possible null datadir becomes the responsibility of the reset() entrypoint in the plugin.
- ALLOW_ROOT=1 allows startup of electrumx on linux (will aim to remove this as soon as possible)
- purging all usage of sudo from linux-specific code paths