### PR TITLE
remove polling of child processes via 'status_check' entrypoint and r…

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,11 +19,6 @@ jobs:
     - script: |
           sudo apt-get update
           sudo apt-get install libusb-1.0-0-dev libudev-dev
-          git clone https://github.com/electrumsv/electrumsv.git
-          cd electrumsv
-          python3 -m pip install -r contrib/deterministic-build/requirements.txt
-          python3 -m pip install -r contrib/deterministic-build/requirements-hw.txt
-          python3 -m pip install -r contrib/deterministic-build/requirements-binaries.txt
           python3 -m pip install pysqlite3-binary
       displayName: 'prepare for electrumsv'
       workingDirectory: electrumsv-sdk/
@@ -90,11 +85,6 @@ jobs:
         versionSpec: 3.7
     - script: |
           brew upgrade sqlite3
-          git clone https://github.com/electrumsv/electrumsv.git
-          cd electrumsv
-          python3 -m pip install -r contrib/deterministic-build/requirements.txt
-          python3 -m pip install -r contrib/deterministic-build/requirements-hw.txt
-          python3 -m pip install -r contrib/deterministic-build/requirements-binaries.txt
       displayName: 'prepare for electrumsv'
       workingDirectory: electrumsv-sdk/
     - script: |

--- a/electrumsv-sdk/electrumsv_sdk/builtin_components/merchant_api/merchant_api.py
+++ b/electrumsv-sdk/electrumsv_sdk/builtin_components/merchant_api/merchant_api.py
@@ -59,10 +59,13 @@ class Plugin(AbstractPlugin):
         # Get the path to the executable file.
         run_path = get_run_path(self.src)
 
+        command = str(run_path)
         logfile = self.plugin_tools.get_logfile_path(self.id)
-        process = self.plugin_tools.spawn_process(str(run_path), env_vars=None, logfile=logfile)
-        self.component_info = Component(self.id, process.pid, self.COMPONENT_NAME,
-            self.src, status_endpoint="http://127.0.0.1:45111/mapi/feeQuote")
+        status_endpoint = "http://127.0.0.1:45111/mapi/feeQuote"
+        self.plugin_tools.spawn_process(command, env_vars=None, id=self.id,
+            component_name=self.COMPONENT_NAME, src=self.src, logfile=logfile,
+            status_endpoint=status_endpoint
+        )
 
     def stop(self):
         """some components require graceful shutdown via a REST API or RPC API but most can use the
@@ -72,14 +75,3 @@ class Plugin(AbstractPlugin):
 
     def reset(self):
         self.logger.info("resetting Merchant API is not applicable")
-
-    def status_check(self) -> Optional[bool]:
-        """
-        True -> ComponentState.RUNNING;
-        False -> ComponentState.FAILED;
-        None -> skip status monitoring updates (e.g. using app's cli interface transiently)
-        """
-        is_running = self.plugin_tools.is_component_running_http(
-            status_endpoint=self.component_info.status_endpoint,
-            retries=5, duration=2, timeout=1.0)
-        return is_running

--- a/electrumsv-sdk/electrumsv_sdk/builtin_components/node/node.py
+++ b/electrumsv-sdk/electrumsv_sdk/builtin_components/node/node.py
@@ -84,17 +84,12 @@ class Plugin(AbstractPlugin):
             print_to_console=True, extra_params=extra_params)
 
         command = " ".join(shell_command)
-        env_vars = None
         logfile = self.plugin_tools.get_logfile_path(self.id)
-        process = self.plugin_tools.spawn_process(command, env_vars=None, logfile=logfile)
-        logging_path = Path(self.datadir).joinpath("regtest/bitcoind.log")
-
-        self.component_info = Component(self.id, process.pid, self.COMPONENT_NAME,
-            str(self.datadir), f"http://rpcuser:rpcpassword@127.0.0.1:{self.port}",
-            logging_path=logging_path,
+        self.plugin_tools.spawn_process(command, env_vars=None, id=self.id,
+            component_name=self.COMPONENT_NAME, src=self.src, logfile=logfile,
+            status_endpoint=f"http://rpcuser:rpcpassword@127.0.0.1:{self.port}",
             metadata={"DATADIR": str(self.datadir), "rpcport": self.port, "p2p_port": self.p2p_port}
         )
-        self.node_status_check_result = True
 
     def stop(self):
         """The bitcoin node requires graceful shutdown via the RPC API - a good example of why this
@@ -120,11 +115,3 @@ class Plugin(AbstractPlugin):
 
         self.plugin_tools.call_for_component_id_or_type(self.COMPONENT_NAME, callable=reset_node)
         self.logger.debug("Reset of RegTest bitcoin daemon completed successfully.")
-
-    def status_check(self) -> Optional[bool]:
-        """
-        True -> ComponentState.RUNNING;
-        False -> ComponentState.FAILED;
-        None -> skip status monitoring updates (e.g. using app's cli interface transiently)
-        """
-        return self.node_status_check_result

--- a/electrumsv-sdk/electrumsv_sdk/builtin_components/whatsonchain/whatsonchain.py
+++ b/electrumsv-sdk/electrumsv_sdk/builtin_components/whatsonchain/whatsonchain.py
@@ -75,12 +75,13 @@ class Plugin(AbstractPlugin):
             "RPC_USERNAME": self.RPC_USERNAME,
             "RPC_PASSWORD": self.RPC_PASSWORD,
         }
-
         self.id = self.plugin_tools.get_id(self.COMPONENT_NAME)
         logfile = self.plugin_tools.get_logfile_path(self.id)
-        process = self.plugin_tools.spawn_process(command, env_vars=env_vars, logfile=logfile)
-        self.component_info = Component(self.id, process.pid, self.COMPONENT_NAME, str(self.src),
-            "http://127.0.0.1:3002")
+        status_endpoint="http://127.0.0.1:3002"
+        self.plugin_tools.spawn_process(command, env_vars=env_vars, id=self.id,
+            component_name=self.COMPONENT_NAME, src=self.src, logfile=logfile,
+            status_endpoint=status_endpoint
+        )
 
     def stop(self):
         """some components require graceful shutdown via a REST API or RPC API but most can use the
@@ -90,14 +91,3 @@ class Plugin(AbstractPlugin):
 
     def reset(self):
         self.logger.info("resetting the whatsonchain is not applicable")
-
-    def status_check(self) -> Optional[bool]:
-        """
-        True -> ComponentState.RUNNING;
-        False -> ComponentState.FAILED;
-        None -> skip status monitoring updates (e.g. using app's cli interface transiently)
-        """
-        is_running = self.plugin_tools.is_component_running_http(
-            status_endpoint=self.component_info.status_endpoint,
-            retries=4, duration=3, timeout=1.0, http_method='get')
-        return is_running

--- a/electrumsv-sdk/electrumsv_sdk/builtin_components/whatsonchain_api/whatsonchain_api.py
+++ b/electrumsv-sdk/electrumsv_sdk/builtin_components/whatsonchain_api/whatsonchain_api.py
@@ -42,9 +42,10 @@ class Plugin(AbstractPlugin):
         command = f"{sys.executable} {self.SCRIPT_PATH}"
         logfile = self.plugin_tools.get_logfile_path(self.id)
         env_vars = {"PYTHONUNBUFFERED": "1"}
-        process = self.plugin_tools.spawn_process(command, env_vars=env_vars, logfile=logfile)
-        self.component_info = Component(self.id, process.pid, self.COMPONENT_NAME,
-            self.COMPONENT_PATH, self.PING_URL)
+        self.plugin_tools.spawn_process(command, env_vars=env_vars, id=self.id,
+            component_name=self.COMPONENT_NAME, src=self.src, logfile=logfile,
+            status_endpoint=self.PING_URL
+        )
 
     def stop(self) -> None:
         self.logger.debug("Attempting to kill the process if it is even running")
@@ -52,14 +53,3 @@ class Plugin(AbstractPlugin):
 
     def reset(self) -> None:
         pass
-
-    def status_check(self) -> Optional[bool]:
-        """
-        True -> ComponentState.RUNNING;
-        False -> ComponentState.FAILED;
-        None -> skip status monitoring updates (e.g. using app's cli interface transiently)
-        """
-        is_running = self.plugin_tools.is_component_running_http(
-            status_endpoint=self.component_info.status_endpoint,
-            retries=5, duration=2, timeout=1.0)
-        return is_running

--- a/electrumsv-sdk/electrumsv_sdk/components.py
+++ b/electrumsv-sdk/electrumsv_sdk/components.py
@@ -56,7 +56,7 @@ class Component:
     def __init__(
         self,
         id: str,
-        pid: int,
+        pid: Optional[int],
         component_type: str,
         location: Union[str, Path],
         status_endpoint: str,
@@ -99,6 +99,9 @@ class Component:
 
 
 class ComponentStore:
+    """multiprocess safe read/write access to component_state.json
+    (which is basically acting as a stand-in for a database - which would be major overkill)"""
+
     def __init__(self):
         self.file_name = "component_state.json"
         self.lock_path = SDK_HOME_DIR / "component_state.json.lock"
@@ -141,6 +144,7 @@ class ComponentStore:
 
         with open(self.component_state_path, "w") as f:
             f.write(json.dumps(component_state, indent=4))
+            f.flush()
         logger.debug(f"updated status: {new_component_info}")
 
     def component_status_data_by_id(self, component_id: str) -> Dict:

--- a/electrumsv-sdk/electrumsv_sdk/components.py
+++ b/electrumsv-sdk/electrumsv_sdk/components.py
@@ -59,7 +59,7 @@ class Component:
         pid: Optional[int],
         component_type: str,
         location: Union[str, Path],
-        status_endpoint: str,
+        status_endpoint: Optional[str],
         component_state:
             Union[ComponentState.RUNNING, ComponentState.STOPPED, ComponentState.FAILED] = None,
         metadata: Optional[dict] = None,

--- a/electrumsv-sdk/electrumsv_sdk/constants.py
+++ b/electrumsv-sdk/electrumsv_sdk/constants.py
@@ -1,9 +1,18 @@
 import os
+import sys
 from pathlib import Path
 
-from .utils import get_sdk_datadir
-
 MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+# copied from utils to avoid circular import
+def get_sdk_datadir():
+    sdk_home_datadir = None
+    if sys.platform == "win32":
+        sdk_home_datadir = Path(os.environ.get("LOCALAPPDATA")) / "ElectrumSV-SDK"
+    if sdk_home_datadir is None:
+        sdk_home_datadir = Path.home() / ".electrumsv-sdk"
+    return sdk_home_datadir
 
 # Directory structure
 SDK_HOME_DIR: Path = get_sdk_datadir()
@@ -48,3 +57,7 @@ class ComponentState:
     RUNNING = "Running"
     STOPPED = "Stopped"
     FAILED = "Failed"
+
+SUCCESS_EXITCODE = 0
+SIGINT_EXITCODE = 130  # (2 + 128)
+SIGKILL_EXITCODE = 137  # (9 + 128)

--- a/electrumsv-sdk/electrumsv_sdk/scripts/run_background.py
+++ b/electrumsv-sdk/electrumsv_sdk/scripts/run_background.py
@@ -1,0 +1,37 @@
+"""
+This script is used in order to launch a background task whilst retaining the ability to call
+process.wait() (blocking the thread) and wrap the process with supervisor logic (thereby
+capturing the exit returncode for immediate feedback to the status monitor).
+"""
+import json
+import logging
+import os
+
+from electrumsv_sdk.components import Component
+from electrumsv_sdk.utils import spawn_background
+
+logger = logging.getLogger("run-background-script")
+
+
+def unwrap_and_unescape_text(arg: str):
+    return arg.strip("\'").replace('\\"', '"')
+
+
+def main():
+    command = unwrap_and_unescape_text(os.environ.get("SCRIPT_COMMAND"))
+    component_info = json.loads(unwrap_and_unescape_text(os.environ.get("SCRIPT_COMPONENT_INFO")))
+    component_info = Component.from_dict(component_info)
+    env_vars = os.environ.copy()
+
+    spawn_background(command, env_vars,
+        id=component_info.id, component_name=component_info.component_type,
+        src=component_info.location, logfile=component_info.logging_path,
+        status_endpoint=component_info.status_endpoint, metadata=component_info.metadata)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        logger.exception("an unexpected exception occurred")
+        input("press any key to close...")

--- a/electrumsv-sdk/electrumsv_sdk/scripts/run_inline.py
+++ b/electrumsv-sdk/electrumsv_sdk/scripts/run_inline.py
@@ -5,12 +5,16 @@ the ability to capture both stdout & logging output to file at the same time
 import argparse
 import json
 import logging
-from pathlib import Path
 
+from electrumsv_sdk.components import Component
 from electrumsv_sdk.utils import spawn_inline
 
 
 logger = logging.getLogger("run-inline-script")
+logging.basicConfig(format='%(asctime)s %(levelname)-8s %(name)-24s %(message)s',
+    level=logging.WARNING, datefmt='%Y-%m-%d %H:%M:%S')
+filelock_logger = logging.getLogger("filelock")
+filelock_logger.setLevel(logging.WARNING)
 
 
 def unwrap_and_unescape_text(arg: str):
@@ -18,28 +22,27 @@ def unwrap_and_unescape_text(arg: str):
 
 
 def main():
-    # todo - add formal input validation / exception handling
     top_level_parser = argparse.ArgumentParser()
     top_level_parser.add_argument("--command", type=str, default="",
         help="one contiguous string command (to run a server)")
     top_level_parser.add_argument("--env_vars", type=str, default="",
         help="environment variables in serialized json format")
-    top_level_parser.add_argument("--logfile", type=str, default="",
-        help="absolute logfile path")
+    top_level_parser.add_argument("--component_info", type=str, default="",
+        help="component_info")
     parsed_args = top_level_parser.parse_args()
     command = unwrap_and_unescape_text(parsed_args.command)
+    component_info = json.loads(unwrap_and_unescape_text(parsed_args.component_info))
+    component_info = Component.from_dict(component_info)
 
     if parsed_args.env_vars:
         env_vars = json.loads(unwrap_and_unescape_text(parsed_args.env_vars))
     else:
         env_vars = None
 
-    if parsed_args.logfile:
-        logfile = Path(unwrap_and_unescape_text(parsed_args.logfile))
-    else:
-        logfile = None
-
-    spawn_inline(command, env_vars, logfile)
+    spawn_inline(command, env_vars,
+        id=component_info.id, component_name=component_info.component_type,
+        src=component_info.location, logfile=component_info.logging_path,
+        status_endpoint=component_info.status_endpoint, metadata=component_info.metadata)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…eplace it with a wrapper around the subprocess.Popen handle.which checks the exit returncode.

- component_state.json is then updated accordingly.
- This means there is always immediate feedback for failed processes and plugin design is simplified (does not require an API network endpoint)
- graceful shutdown via signal.CTRL_C_EVENT on windows
- simplify down controller.stop() - no longer needs to update component_state.json