### PR TITLE
Test migration from older SDK version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,9 +38,9 @@ jobs:
     postgres: pg12
 
   variables:
-    MODIFIED_SDK_HOME_DIR: $(Agent.HomeDirectory)/my_portable_sdk_datadir
-    NEW_LOG_DIR: $(Agent.HomeDirectory)/my_portable_sdk_datadir/logs
-    SDK_LOG_LEVEL: "INFO"
+    MODIFIED_SDK_HOME_DIR:  $(Agent.HomeDirectory)/my_portable_sdk_datadir
+    NEW_LOG_DIR:            $(Agent.HomeDirectory)/my_portable_sdk_datadir/logs
+    SDK_LOG_LEVEL:          INFO
 
   steps:
     - task: UsePythonVersion@0
@@ -166,9 +166,9 @@ jobs:
     vmImage: 'macOS-latest'
 
   variables:
-    MODIFIED_SDK_HOME_DIR: $(Agent.HomeDirectory)/my_portable_sdk_datadir
-    NEW_LOG_DIR: $(Agent.HomeDirectory)/my_portable_sdk_datadir/logs
-    SDK_LOG_LEVEL: "INFO"
+    MODIFIED_SDK_HOME_DIR:  $(Agent.HomeDirectory)/my_portable_sdk_datadir
+    NEW_LOG_DIR:            $(Agent.HomeDirectory)/my_portable_sdk_datadir/logs
+    SDK_LOG_LEVEL:          INFO
 
   steps:
     # https://stackoverflow.com/questions/27700596/homebrew-postgres-broken
@@ -371,6 +371,111 @@ jobs:
     - task: PublishBuildArtifacts@1
       inputs:
         pathToPublish: $(NEW_LOG_DIR)
+        artifactName: 'WindowsLogs'
+      displayName: 'Publish logs'
+
+# Peace of mind that there is no conflict with previously installed SDK version.
+- job: TestWindowsVersionMigration
+
+  pool:
+    vmImage: 'windows-latest'
+
+  services:
+    postgres: pg12-win32
+
+  variables:
+    LOG_DIR:                C:\Users\VssAdministrator\AppData\Local\ElectrumSV-SDK\logs
+    SDK_LOG_LEVEL:          INFO
+    PREVIOUS_SDK_VERSION:   0.0.36
+
+  steps:
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: 3.9
+        addToPath: true
+        architecture: 'x64'
+
+    # need to add python Scripts/ dir to PATH to find 'electrumsv-sdk' command
+    - pwsh: |
+        $scripts_dir = py -3.9 -c "import os, sys, pathlib;print(pathlib.Path(sys.executable).parent.joinpath(r'Scripts'));"
+        $env:PATH += $scripts_dir
+        py -3.9 -m pip install --upgrade pip
+        py -3.9 -m pip install wheel
+        py -3.9 -m pip install electrumsv-sdk==$(PREVIOUS_SDK_VERSION)
+        py -3.9 -m pip install pytest pytest-cov
+      displayName: 'install electrumsv-sdk'
+
+# Todo - uncomment this when PREVIOUS_SDK_VERSION>=0.0.37
+#    - script: |
+#        set -e
+#        electrumsv-sdk config --sdk-home-dir=$(MODIFIED_SDK_HOME_DIR)
+#      displayName: 'configure for portable sdk-home-dir'
+
+# Todo - add back merchant_api testing from install/start/stop/reset when PREVIOUS_SDK_VERSION>=0.0.37
+
+    - script: |
+        cd $(Build.Repository.LocalPath)/contrib/azure
+        python3 -m pip install asyncpg
+        python3 ./mapi_db_config.py
+      displayName: 'prepare postgres'
+
+    - script: |
+        electrumsv-sdk install node
+        electrumsv-sdk install electrumx
+        electrumsv-sdk install electrumsv
+        electrumsv-sdk install whatsonchain
+
+      displayName: 'install all components'
+
+    - script: |
+        electrumsv-sdk start --background status_monitor
+        electrumsv-sdk start --background --new node
+        electrumsv-sdk start --background --new electrumx
+        electrumsv-sdk start --background --new --deterministic-seed electrumsv
+        electrumsv-sdk node generate 1
+        electrumsv-sdk start --background whatsonchain
+
+        electrumsv-sdk status
+        python3 ./contrib/check_all_started.py
+      displayName: 'start all components'
+      continueOnError: true
+
+    - script: |
+        electrumsv-sdk stop node
+        electrumsv-sdk stop electrumx
+        electrumsv-sdk stop electrumsv
+        electrumsv-sdk stop whatsonchain
+        electrumsv-sdk stop status_monitor
+
+        electrumsv-sdk status
+        python3 ./contrib/check_all_stopped.py
+      displayName: 'stop all components'
+      continueOnError: true
+
+    - script: |
+        sleep 5
+        electrumsv-sdk reset node
+        electrumsv-sdk reset electrumx
+        electrumsv-sdk reset electrumsv
+        electrumsv-sdk reset whatsonchain
+        electrumsv-sdk reset status_monitor
+
+        electrumsv-sdk status
+      displayName: 'reset all components'
+      continueOnError: true
+
+    - script: |
+        sleep 5
+        electrumsv-sdk reset --id=node1 node
+        electrumsv-sdk reset --id=electrumx1 electrumx
+        electrumsv-sdk reset --id=electrumsv1 --deterministic-seed electrumsv
+        electrumsv-sdk status
+      displayName: 'reset by id'
+      continueOnError: true
+
+    - task: PublishBuildArtifacts@1
+      inputs:
+        pathToPublish: $(LOG_DIR)
         artifactName: 'WindowsLogs'
       displayName: 'Publish logs'
 

--- a/electrumsv_sdk/builtin_components/merchant_api/merchant_api.py
+++ b/electrumsv_sdk/builtin_components/merchant_api/merchant_api.py
@@ -10,7 +10,8 @@ from electrumsv_sdk.components import Component
 from electrumsv_sdk.utils import get_directory_name, kill_process
 from electrumsv_sdk.plugin_tools import PluginTools
 
-from .install import download_and_install, load_env_vars, get_run_path, chmod_exe
+from .install import download_and_install, load_env_vars, get_run_path, chmod_exe, \
+    MERCHANT_API_VERSION
 from .check_db_config import check_postgres_db, drop_db_on_install
 
 
@@ -63,8 +64,14 @@ class Plugin(AbstractPlugin):
 
         # EXE RUN MODE
         load_env_vars()
-        chmod_exe(self.src)
-        command = get_run_path(self.src)
+        try:
+            chmod_exe(self.src)
+            command = get_run_path(self.src)
+        except FileNotFoundError:
+            self.logger.error(f"Could not find version: {MERCHANT_API_VERSION} of the "
+                f"merchant_api. Have you tried re-running 'electrumsv-sdk install merchant_api' to "
+                f"pull the latest version?")
+            return
 
         logfile = self.plugin_tools.get_logfile_path(self.id)
         status_endpoint = "http://127.0.0.1:45111/mapi/feeQuote"


### PR DESCRIPTION
- excluding merchant_api because would need to add back SSL scripts and is not worth the effort when I can just test it locally instead (just this once - can add merchant_api from next version onwards.